### PR TITLE
Increased dhclient timeout from default(60s) to 300s in config

### DIFF
--- a/ec2net-functions
+++ b/ec2net-functions
@@ -200,6 +200,7 @@ EOF
   # the expected interface, and dhclient accepts the lease offer.
   cat <<- EOF > ${dhclient_file}
 	supersede dhcp-server-identifier 255.255.255.255;
+        timeout 300;
 EOF
 }
 


### PR DESCRIPTION

*Issue #, if available:*
https://github.com/aws/ec2-net-utils/issues/4

*Description of changes:*
Increased dhclient timeout from default(60s) to 300s in generated dhclient config file.

For large VPC dhcp discovery might take more than 60 seconds causing kernel routing table to not be properly updated.

